### PR TITLE
Toggle Deposits and Withdrawals

### DIFF
--- a/src/core/command/deposit.ts
+++ b/src/core/command/deposit.ts
@@ -1,5 +1,7 @@
 import { CommandContext } from 'grammy';
 import { getNextQuarterMonth, isLoggedIn, MyContext, trackMessage } from '../helpers/helpers';
+import { settings } from '../config/application';
+import { transactionsNotAllowed } from '../helpers/constants';
 
 const messageIds: number[] = [];
 
@@ -8,24 +10,30 @@ export const handleDeposit = async (ctx: CommandContext<MyContext>): Promise<voi
   messageIds.push(ctx.message?.message_id as number);
 
   if (isLoggedIn(ctx.session.token)) {
-    await getNextQuarterMonth(ctx, messageIds);
+    if (settings.allowDepositsAndWithdrawals) {
+      await getNextQuarterMonth(ctx, messageIds);
 
-    const reply = await ctx.reply('Choose plan to deposit into: ', {
-      reply_markup: {
-        inline_keyboard: [
-          [
-            { text: 'HIGH RISK', callback_data: 'high_risk_deposit' },
-            { text: 'MEDIUM RISK', callback_data: 'medium_risk_deposit' }
-          ],
-          [
-            { text: 'LOW RISK', callback_data: 'low_risk_deposit' },
-            { text: 'CANCEL', callback_data: 'cancel' }
+      const reply = await ctx.reply('Choose plan to deposit into: ', {
+        reply_markup: {
+          inline_keyboard: [
+            [
+              { text: 'HIGH RISK', callback_data: 'high_risk_deposit' },
+              { text: 'MEDIUM RISK', callback_data: 'medium_risk_deposit' }
+            ],
+            [
+              { text: 'LOW RISK', callback_data: 'low_risk_deposit' },
+              { text: 'CANCEL', callback_data: 'cancel' }
+            ]
           ]
-        ]
-      }
-    });
-    messageIds.push(reply.message_id);
-    ctx.session.route = '';
+        }
+      });
+      messageIds.push(reply.message_id);
+      ctx.session.route = '';
+    } else {
+      const reply = await ctx.reply(transactionsNotAllowed, { parse_mode: 'HTML' });
+      messageIds.push(reply.message_id);
+      ctx.session.route = '';
+    }
   } else {
     const reply = await ctx.reply('<b>Login Required</b> 🔒\n\nUse /login to access this feature.', { parse_mode: 'HTML' });
     messageIds.push(reply.message_id);

--- a/src/core/command/withdraw.ts
+++ b/src/core/command/withdraw.ts
@@ -1,5 +1,7 @@
 import { CommandContext } from 'grammy';
 import { checkSubscribedPlans, isLoggedIn, MyContext, trackMessage } from '../helpers/helpers';
+import { settings } from '../config/application';
+import { transactionsNotAllowed } from '../helpers/constants';
 
 const messageIds: number[] = [];
 
@@ -9,7 +11,13 @@ export const handleWithdrawal = async (ctx: CommandContext<MyContext>): Promise<
   messageIds.push(ctx.message?.message_id as number);
 
   if (isLoggedIn(ctx.session.token)) {
-    await checkSubscribedPlans(ctx, userData);
+    if (settings.allowDepositsAndWithdrawals) {
+      await checkSubscribedPlans(ctx, userData);
+    } else {
+      const reply = await ctx.reply(transactionsNotAllowed, { parse_mode: 'HTML' });
+      messageIds.push(reply.message_id);
+      ctx.session.route = '';
+    }
   } else {
     const reply = await ctx.reply('**User does not exist** 🚫\n\n Please /login to perform this action');
     messageIds.push(reply.message_id);

--- a/src/core/config/application.ts
+++ b/src/core/config/application.ts
@@ -12,5 +12,6 @@ export const settings = {
   adminIds: {
     chatId1: process.env.ADMINCHATID1 as string,
     chatId2: process.env.ADMINCHATID2 as string
-  }
+  },
+  allowDepositsAndWithdrawals: process.env.ALLOW_DEPOSIT_WITHDRAWAL as unknown as boolean
 };

--- a/src/core/helpers/constants.ts
+++ b/src/core/helpers/constants.ts
@@ -23,3 +23,4 @@ export const pickSecurityQuestion = '<b>Pick a Security Question for your Accoun
 export const inputROI = 'Input quarters ROI';
 export const validROIMessage = 'Please input a valid ROI amount, between -100% and 200%';
 export const approvalMessage = 'Okay. Will let the user know it has been approved';
+export const transactionsNotAllowed = '<b>Deposits and Withdrawals are currently disabled till the end of the quarter.</b>';


### PR DESCRIPTION
#### WHY THIS PR?
- To give us more control over when deposits and withdrawals are allowed, without modifying code.

#### WHAT DOES THIS PR DO?
- Introduces a new environment variable to toggle deposits and withdrawals
- Updates relevant checks to respect the new toggle
- Prevents deposit/withdrawal actions when the toggle is off

#### HOW CAN THIS PR BE TESTED?
- Set `ALLOW_DEPOSIT_WITHDRAWAL=false` in your `.env`
- Run `npm run dev` in your terminal
-Attempt a deposit or withdrawal - it should be blocked
- Change it back to true and verify that it works again

Reviewer Notes
- This change improves flexibility in managing transaction windows
- Make sure to test both states of the toggle (true and false) for accuracy